### PR TITLE
Add 3D transformation support to Matrix 3x3 class

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -8,6 +8,7 @@
 if(NOT TARGET UtilsCPP)
     find_program(GIT_PATH git REQUIRED)
     execute_process(COMMAND ${GIT_PATH} submodule update --init UtilsCPP WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set(UTILSCPP_BUILD_TESTS OFF)
     add_subdirectory(UtilsCPP)
 endif()
 set_target_properties(UtilsCPP PROPERTIES FOLDER "dependencies")

--- a/include/Math/Matrix.hpp
+++ b/include/Math/Matrix.hpp
@@ -43,6 +43,11 @@ public:
 
     Matrix(const mat4x4&);
 
+    static mat3x3 rotation(const vec3f& rads);
+    static mat3x3 scale(const vec3f& vals);
+
+    static mat3x3 translation(const vec2f& vals);
+
     ~Matrix() = default;
 
 private:
@@ -78,9 +83,10 @@ public:
 
     Matrix(const mat3x3&);
 
-    static mat4x4 rotation(const vec3f& rads);
+    inline static mat4x4 rotation(const vec3f& rads) { return mat4x4(mat3x3::rotation(rads)); }
+    inline static mat4x4 scale(const vec3f& vals) { return mat4x4(mat3x3::scale(vals)); }
+
     static mat4x4 translation(const vec3f& vals);
-    static mat4x4 scale(const vec3f& vals);
 
     float determinant() const;
     mat4x4 inversed() const;

--- a/src/Matrix3x3f.cpp
+++ b/src/Matrix3x3f.cpp
@@ -10,6 +10,7 @@
 #include "Math/Matrix.hpp"
 #include "Math/Vector.hpp"
 #include "UtilsCPP/RuntimeError.hpp"
+#include <cmath>
 
 namespace math
 {

--- a/src/Matrix3x3f.cpp
+++ b/src/Matrix3x3f.cpp
@@ -99,4 +99,48 @@ mat3x3 operator * (const mat3x3& lhs, const mat3x3& rhs)
     };
 }
 
+mat3x3 mat3x3::rotation(const vec3f& rads)
+{
+    using std::cos;
+    using std::sin;
+
+    math::mat3x3 rotX(
+        1,           0,            0,
+        0, cos(rads.x), -sin(rads.x),
+        0, sin(rads.x),  cos(rads.x)
+    );
+
+    math::mat3x3 rotY(
+        cos(rads.y), 0, sin(rads.y),
+                  0, 1,           0,
+       -sin(rads.y), 0, cos(rads.y)
+    );
+
+    math::mat3x3 rotZ(
+        cos(rads.z), -sin(rads.z), 0,
+        sin(rads.z),  cos(rads.z), 0,
+                  0,            0, 1
+    );
+
+    return rotY * rotX * rotZ;
+}
+
+mat3x3 mat3x3::scale(const vec3f& vals)
+{
+    return {
+        vals.x,      0,      0,
+             0, vals.y,      0,
+             0,      0, vals.z
+    };
+}
+
+mat3x3 mat3x3::translation(const vec2f& vals)
+{
+    return {
+        1, 0, vals.x,
+        0, 1, vals.y,
+        0, 0,      1
+    };
+}
+
 }

--- a/src/Matrix4x4f.cpp
+++ b/src/Matrix4x4f.cpp
@@ -10,7 +10,6 @@
 #include "Math/Matrix.hpp"
 #include "Math/Vector.hpp"
 #include "UtilsCPP/RuntimeError.hpp"
-#include <cmath>
 
 namespace math
 {
@@ -156,35 +155,6 @@ mat4x4 operator * (const mat4x4& lhs, const mat4x4& rhs)
     };
 }
 
-mat4x4 mat4x4::rotation(const vec3f& rads)
-{
-    using std::cos;
-    using std::sin;
-
-    math::mat4x4 rotX(
-        1,           0,            0, 0,
-        0, cos(rads.x), -sin(rads.x), 0,
-        0, sin(rads.x),  cos(rads.x), 0,
-        0,           0,            0, 1
-    );
-
-    math::mat4x4 rotY(
-        cos(rads.y), 0, sin(rads.y), 0,
-                  0, 1,           0, 0,
-       -sin(rads.y), 0, cos(rads.y), 0,
-                  0, 0,           0, 1
-    );
-
-    math::mat4x4 rotZ(
-        cos(rads.z), -sin(rads.z), 0, 0,
-        sin(rads.z),  cos(rads.z), 0, 0,
-                  0,            0, 1, 0,
-                  0,            0, 0, 1
-    );
-
-    return rotY * rotX * rotZ;
-}
-
 mat4x4 mat4x4::translation(const vec3f& vals)
 {
     return {
@@ -192,16 +162,6 @@ mat4x4 mat4x4::translation(const vec3f& vals)
         0, 1, 0, vals.y,
         0, 0, 1, vals.z,
         0, 0, 0,      1
-    };
-}
-
-mat4x4 mat4x4::scale(const vec3f& vals)
-{
-    return {
-        vals.x,      0,      0, 0,
-             0, vals.y,      0, 0,
-             0,      0, vals.z, 0,
-             0,      0,      0, 1
     };
 }
 

--- a/src/Vector3f.cpp
+++ b/src/Vector3f.cpp
@@ -39,7 +39,8 @@ float vec3f::length() const
 void vec3f::normalize()
 {
     float len = length();
-
+    if (len == 0)
+        return;
     x /= len;
     y /= len;
     z /= len;


### PR DESCRIPTION
This pull request adds the `rotation`, `scale`, and `translation` static methods to the `Matrix` class, allowing for 3D transformations. The `rotation` method calculates a rotation matrix based on Euler angles, the `scale` method creates a scaling matrix, and the `translation` method generates a translation matrix. These new methods enhance the functionality of the `Matrix` class and enable more complex transformations in 2D and 3D graphics applications.